### PR TITLE
Replace deprecated ARKit api calls

### DIFF
--- a/arkit-demo/Demos/PlaneAnchorViewController.swift
+++ b/arkit-demo/Demos/PlaneAnchorViewController.swift
@@ -26,8 +26,8 @@ class PlaneAnchorViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if ARWorldTrackingSessionConfiguration.isSupported {
-            let configuration = ARWorldTrackingSessionConfiguration()
+        if ARWorldTrackingConfiguration.isSupported {
+            let configuration = ARWorldTrackingConfiguration()
             configuration.planeDetection = .horizontal
             self.sceneView.session.run(configuration)
         }

--- a/arkit-demo/Demos/PlaneMapperViewController.swift
+++ b/arkit-demo/Demos/PlaneMapperViewController.swift
@@ -34,8 +34,8 @@ class PlaneMapperViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if ARWorldTrackingSessionConfiguration.isSupported {
-            let configuration = ARWorldTrackingSessionConfiguration()
+        if ARWorldTrackingConfiguration.isSupported {
+            let configuration = ARWorldTrackingConfiguration()
             configuration.planeDetection = .horizontal
             self.sceneView.session.run(configuration)
         }

--- a/arkit-demo/Demos/SimpleShapeViewController.swift
+++ b/arkit-demo/Demos/SimpleShapeViewController.swift
@@ -26,11 +26,11 @@ class SimpleShapeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if ARWorldTrackingSessionConfiguration.isSupported {
-            let configuration = ARWorldTrackingSessionConfiguration()
+        if ARWorldTrackingConfiguration.isSupported {
+            let configuration = ARWorldTrackingConfiguration()
             self.sceneView.session.run(configuration)
-        } else if ARSessionConfiguration.isSupported {
-            let configuration = ARSessionConfiguration()
+        } else if ARConfiguration.isSupported {
+            let configuration = AROrientationTrackingConfiguration()
             self.sceneView.session.run(configuration)
         }
     }

--- a/arkit-demo/HomeViewController.swift
+++ b/arkit-demo/HomeViewController.swift
@@ -32,7 +32,7 @@ class HomeViewController: UITableViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        if !ARSessionConfiguration.isSupported {
+        if !ARConfiguration.isSupported {
             let alert = UIAlertController(title: "Device Requirement", message: "Sorry, this app only runs on devices that support augmented reality through ARKit.", preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
             self.present(alert, animated: true, completion: nil)


### PR DESCRIPTION
This PR updates the deprecated api calls for ARKit for Xcode 9.  The project as of today (10/27/2017) will not compile with Xcode 9 without this update.

* `ARWorldTrackingSessionConfiguration` has been updated to `ARWorldTrackingConfiguration`.
* `ARSessionConfiguration` has been updated to `ARConfiguration`.
* `ARSessionConfiguration` no longer can be instantiated.  For the purposes of this demo `ARSessionConfiguration` has been updated to `AROrientationTrackingConfiguration`.

After this update the project will now compile with Xcode 9.